### PR TITLE
Updated paperclip to fix URI.escape bug in image upload dialog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rich', git: 'https://github.com/nomadli/rich.git', tag: '1.5.3'
 gem 'kaminari'
 gem 'htmlentities'
-gem 'paperclip', '~> 6.1.0'
+gem 'kt-paperclip', '~> 7.2', '>= 7.2.1'
 gem 'pandoc-ruby'
 
 # It is needed for upgrading CKEditor


### PR DESCRIPTION
Please switch to the new version of paperclip as the old project has been abandoned and is using a functionality which has been removed (URI.escape)